### PR TITLE
lib(exports): make useful constants public

### DIFF
--- a/protocol/tests/regtest.sh
+++ b/protocol/tests/regtest.sh
@@ -1,3 +1,6 @@
 bitcoind --chain=regtest --txindex --blockfilterindex --peerblockfilters --rpcport=18443 --rpcuser=test --rpcpassword=b324 --rest=1 --server=1 --listen=1 --v2transport=1 &
 sleep 1
 cargo test regtest_handshake -- --nocapture
+sleep 1
+## In case of failure this will stop core anyway.
+bitcoin-cli --chain=regtest --rpcuser=test --rpcpassword=b324 stop


### PR DESCRIPTION
If a user isn't using `ReceivedMessage` then they should be able to access the decoy byte which is a somwhat arbitrary number. Also did some const renaming for clarity