### PR TITLE
fix(lib): avoid message cloning within ReceivedMessage

### DIFF
--- a/protocol/tests/round_trips.rs
+++ b/protocol/tests/round_trips.rs
@@ -148,7 +148,7 @@ fn regtest_handshake() {
     let msg = decrypter
         .decrypt_contents_with_alloc(&response_message, None)
         .unwrap();
-    let message = ReceivedMessage::new(&msg.clone()).unwrap();
+    let message = ReceivedMessage::new(msg).unwrap();
     let message = deserialize(&message.message.unwrap()).unwrap();
     dbg!("{}", message.cmd());
     assert_eq!(message.cmd(), "version");

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -144,7 +144,7 @@ pub async fn read_v2<T: AsyncRead + Unpin>(
         .decrypt_contents_with_alloc(&packet_bytes, None)
         .expect("decrypt");
 
-    let contents = ReceivedMessage::new(&raw)
+    let contents = ReceivedMessage::new(raw)
         .expect("some bytes")
         .message
         .expect("not a decoy");


### PR DESCRIPTION
`to_vec()` was calling `T: Clone` for `&[T]` so we just take ownership here instead