### PR TITLE
Allow access to `session_id`

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -339,6 +339,8 @@ impl PacketWriter {
 /// Encrypt and decrypt messages with a peer.
 #[derive(Clone, Debug)]
 pub struct PacketHandler {
+    /// A unique identifier for the communication session.
+    pub session_id: [u8; 32],
     packet_reader: PacketReader,
     packet_writer: PacketWriter,
 }
@@ -354,6 +356,7 @@ impl PacketHandler {
                 let packet_decoding_cipher =
                     FSChaCha20Poly1305::new(materials.responder_packet_key);
                 PacketHandler {
+                    session_id: materials.session_id,
                     packet_reader: PacketReader {
                         length_decoding_cipher,
                         packet_decoding_cipher,
@@ -372,6 +375,7 @@ impl PacketHandler {
                 let packet_decoding_cipher =
                     FSChaCha20Poly1305::new(materials.initiator_packet_key);
                 PacketHandler {
+                    session_id: materials.session_id,
                     packet_reader: PacketReader {
                         length_decoding_cipher,
                         packet_decoding_cipher,


### PR DESCRIPTION
Each packet handler should be one-to-one with a session ID, so I allow access to a field on the struct here. Resolves #61 

cc @nyonson @Kixunil 