### PR TITLE
Handle decoy packets in handshake

### DIFF
--- a/protocol/tests/round_trips.rs
+++ b/protocol/tests/round_trips.rs
@@ -31,10 +31,10 @@ fn hello_world_happy_path() {
         .unwrap();
 
     init_handshake
-        .authenticate_garbage_and_version(&resp_message[64..])
+        .authenticate_garbage_and_version_with_alloc(&resp_message[64..])
         .unwrap();
     resp_handshake
-        .authenticate_garbage_and_version(&init_finalize_message)
+        .authenticate_garbage_and_version_with_alloc(&init_finalize_message)
         .unwrap();
 
     let mut alice = init_handshake.finalize().unwrap();
@@ -111,7 +111,7 @@ fn regtest_handshake() {
     let response = &mut max_response[..size];
     dbg!("Authenticating the handshake");
     handshake
-        .authenticate_garbage_and_version(response)
+        .authenticate_garbage_and_version_with_alloc(response)
         .unwrap();
     dbg!("Finalizing the handshake");
     let packet_handler = handshake.finalize().unwrap();


### PR DESCRIPTION
This adds support for receiving (and ignoring) decoy packets in the handshake before the final version packet is sent.

Without this patch, our handshake fails if any decoy packets are sent in the handshake because it currently assumes that only a version packet is sent. This hasn't bitten us yet because Core doesn't send decoys, but it is definitely not meeting the spec. The [spec](https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki?plain=1#L126) has the specifics on the decoy packets. 

> Encrypted packets have an '''ignore bit''', which makes them '''decoy packets''' if set. Decoy packets are to be ignored by the receiver apart from verifying they decrypt correctly. Either peer may send such decoy packets at any point from here on. These form the primary shapability mechanism in the protocol. How and when to use them is out of scope for this document.

They can be sent immediately after the garbage terminator in the handshake ("here" in the above quote is right after the materials are generated, before the version packet). The only requirement is that the first packet sent, which can be a decoy or the version packet, has the garbage authentication in the AAD. Other than that there are actually very little requirements for the decoy packets which makes them a bit of burden.

Closes #28

## Core Support

As of v28.0rc2, Core does not support sending decoys in the handshake. In [V2Transport::ProcessReceivedKeyBytes](https://github.com/bitcoin/bitcoin/blob/v28.0rc2/src/net.cpp#L1087-L1145), the version packet is sent right after the garbage terminator. This has been Core's behavior since BIP324 was implemented in v26. This begs the question, should this complexity of decoy packets in the handshake even exist?

## Handshake Tweaks

The `Handshake` is attempting to do a lot under the hood for the caller before handing off responsibilities with the `PacketHandler`. The `PacketHandler` is able to pretty easily expose the allocation responsibilities to the caller, they either need the 3 bytes for length or the length of the message. In the `Handshake` however there might be a variable amount of decoy packets right in the middle. Even though decoy messages ideally look like real communication, so I don't believe there is much incentive to send super large packets, this flexibility in the spec is tough to handle without allocation. I think there are three possible options.

1. Set a const `MAX_HANDSHAKE_PACKET_BYTES` where the library guesses the max size of all decoy packets in the handshake. This hides the complexity entirely from the caller, but the trade off is that a large decoy package will blow the whole thing up. Feels pretty fragile since there are no bounds in the spec.
2. Decompose the "authentication" step of the handshake into more calls so that the caller can allocate the exact amount for every decoy packet. This is the most efficient from a memory perspective, but puts a large complexity burden on the caller who doesn't even care about the decoy packets. It essentially exposes the PacketReader interface on the Handshake just for the decoys.
3. A middle ground where an initial allocation is accepted to use as a buffer for decoy packets. If too large of a packet is processed, an error is returned with the required allocation amount to allow the caller to re-allocate and re-try with the larger buffer.
4. An "in-place" decryption function is exposed on the packet handler so the decoy packets are decrypted in place, no longer requiring a buffer to be allocated. This is a large interface tweak and exposes a lot of new complexities to the caller. The authenticate function would also have to require a mutable buffer which may be confusing to the caller who is not expecting any mutations to occur in the authentication.

I went with option 3 and added a new error variant to the module, `BufferTooSmall`, which is returned by the handshake function if it is unable to decrypt the decoy and version packets. A `authenticate_garbage_and_version_with_alloc` wrapper function which requires `alloc` also shows a nice pattern for callers to expand their buffers when necessary.

## Error Variants

I added the `BufferTooSmall` variant and noticed we had been abusing `MessageLengthTooSmall` in a few spots. We may want to consider renaming that one for its remaining use cases.

## Next Up

Plan is to add decoy sending support, along with more unit tests, in a follow up patch. The sending functions will make it way easier to add tests. All existing tests are covering the pre-decoy paths which is all we support at the moment so feel pretty good about this one for now.