### PR TITLE
Harden regtest script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,12 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,7 +65,6 @@ name = "bip324"
 version = "0.3.1"
 dependencies = [
  "bitcoin",
- "bitcoincore-rpc",
  "hex-conservative",
  "rand",
 ]
@@ -104,7 +97,6 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
- "serde",
 ]
 
 [[package]]
@@ -112,9 +104,6 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitcoin-io"
@@ -129,7 +118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
  "bitcoin-internals",
- "serde",
 ]
 
 [[package]]
@@ -140,31 +128,6 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
- "serde",
-]
-
-[[package]]
-name = "bitcoincore-rpc"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
-dependencies = [
- "bitcoincore-rpc-json",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bitcoincore-rpc-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
-dependencies = [
- "bitcoin",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -273,24 +236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "jsonrpc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
-dependencies = [
- "base64",
- "minreq",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,18 +252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,17 +259,6 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
-]
-
-[[package]]
-name = "minreq"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763d142cdff44aaadd9268bebddb156ef6c65a0e13486bb81673cf2d8739f9b0"
-dependencies = [
- "log",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -471,12 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,9 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes",
- "rand",
  "secp256k1-sys",
- "serde",
 ]
 
 [[package]]
@@ -521,18 +435,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -19,7 +19,6 @@ bitcoin = { version = "0.32.0", default-features = false }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.0" }
-bitcoincore-rpc = "0.19.0"
 
 [lib]
 name = "bip324"

--- a/protocol/tests/regtest.sh
+++ b/protocol/tests/regtest.sh
@@ -1,6 +1,48 @@
-bitcoind --chain=regtest --txindex --blockfilterindex --peerblockfilters --rpcport=18443 --rpcuser=test --rpcpassword=b324 --rest=1 --server=1 --listen=1 --v2transport=1 &
-sleep 1
-cargo test regtest_handshake -- --nocapture
-sleep 1
-## In case of failure this will stop core anyway.
-bitcoin-cli --chain=regtest --rpcuser=test --rpcpassword=b324 stop
+#!/usr/bin/env bash
+#
+# Test a handshake with a running bitcoin daemon.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+BITCOIND_PID=""
+
+cleanup() {
+    echo "Cleaning up..."
+    if [ -n "$BITCOIND_PID" ]; then
+        bitcoin-cli --chain=regtest --rpcuser=test --rpcpassword=b324 stop
+        # Wait for the bitcoind process to stop.
+        wait $BITCOIND_PID
+    fi
+}
+
+# Ensure the bitcoind process is cleaned up if this script is killed for any reason.
+trap cleanup EXIT
+
+start_bitcoind() {
+    bitcoind --chain=regtest --txindex --blockfilterindex --peerblockfilters \
+             --rpcport=18443 --rpcuser=test --rpcpassword=b324 --rest=1 \
+             --server=1 --listen=1 --v2transport=1 &
+    BITCOIND_PID=$!
+    
+    echo "Waiting for bitcoind to start..."
+    until bitcoin-cli --chain=regtest --rpcuser=test --rpcpassword=b324 getblockchaininfo &>/dev/null
+    do
+        sleep 1
+    done
+    echo "bitcoind started."
+}
+
+run_tests() {
+    cargo test regtest_handshake -- --ignored --nocapture
+    TEST_EXIT_CODE=$?
+    return $TEST_EXIT_CODE
+}
+
+main() {
+    start_bitcoind
+    run_tests
+    return $?
+}
+
+main

--- a/protocol/tests/round_trips.rs
+++ b/protocol/tests/round_trips.rs
@@ -79,7 +79,7 @@ fn regtest_handshake() {
         serde::{deserialize, serialize, NetworkMessage},
         Handshake, PacketType,
     };
-    use bitcoincore_rpc::bitcoin::p2p::{message_network::VersionMessage, Address, ServiceFlags};
+    use bitcoin::p2p::{message_network::VersionMessage, Address, ServiceFlags};
 
     let mut stream = TcpStream::connect(format!("127.0.0.1:{PORT}")).unwrap();
     let mut public_key = [0u8; 64];


### PR DESCRIPTION
regtest.sh was outputting some confusing noise when testing locally, so added a few smarts to the script to clean up the bitcoind instance.

* `regtest.sh` is now entirely responsible for starting and stopping the require bitcoind daemon. The test no longer calls `stop` at the end, it gets to just focus on testing.
* Dropped the rpc dependency since the test no longer needs to call it.
* The `dbg!` macro usage was causing some confusing double output. I believe our use case is better suited by just `println!`.