### PR TITLE
Mark optional deps optional to keep out of dependency tree when not used

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,7 +15,7 @@ std = ["alloc", "bitcoin/std", "rand/std", "rand/std_rng"]
 alloc = []
 
 [dependencies]
-futures = { version = "0.3.30", default-features = false }
+futures = { version = "0.3.30", default-features = false, optional = true }
 rand = { version = "0.8.0", default-features = false }
 bitcoin = { version = "0.32.0", default-features = false }
 


### PR DESCRIPTION
Checked with `cargo tree -p bip324 -F async --edges features`