### PR TITLE
Upgrade `bitcoin` to `0.32.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
 dependencies = [
  "base58ck",
  "bech32",

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -17,7 +17,7 @@ alloc = []
 [dependencies]
 futures = { version = "0.3.30", default-features = false, optional = true }
 rand = { version = "0.8.0", default-features = false }
-bitcoin = { version = "0.32.0", default-features = false }
+bitcoin = { version = "0.32.4", default-features = false }
 
 [dev-dependencies]
 hex = { package = "hex-conservative", version = "0.2.0" }

--- a/protocol/src/serde.rs
+++ b/protocol/src/serde.rs
@@ -10,7 +10,6 @@ use alloc::vec::Vec;
 use bitcoin::{
     block,
     consensus::{encode, Decodable, Encodable},
-    io::BufRead,
     VarInt,
 };
 
@@ -296,7 +295,7 @@ struct HeaderDeserializationWrapper(Vec<block::Header>);
 
 impl Decodable for HeaderDeserializationWrapper {
     #[inline]
-    fn consensus_decode_from_finite_reader<R: BufRead + ?Sized>(
+    fn consensus_decode_from_finite_reader<R: bitcoin::io::Read + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
         let len = VarInt::consensus_decode(r)?.0;


### PR DESCRIPTION
Small break in the trait bounds on `Decodable` fixed here