### PR TITLE
Add tokio feature flag for easier integration with the async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -77,6 +77,7 @@ dependencies = [
  "futures",
  "hex-conservative",
  "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -91,7 +92,6 @@ dependencies = [
  "hex-conservative",
  "log",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -418,14 +418,23 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
- "windows-sys",
 ]
 
 [[package]]
@@ -457,7 +466,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -670,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -695,45 +704,32 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -809,7 +805,16 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -818,7 +823,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -827,15 +847,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -845,9 +871,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -863,9 +901,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -875,9 +925,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,11 +11,14 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 async = ["std", "futures/std"]
+tokio = ["std", "tokio/io-util"]
 std = ["alloc", "bitcoin/std", "rand/std", "rand/std_rng"]
 alloc = []
 
 [dependencies]
 futures = { version = "0.3.30", default-features = false, optional = true }
+# Must be under 1.39.0 due to MSRV 1.63.0 requirement.
+tokio = { version = ">=1.37.0, <1.39.0", default-features = false, optional = true }
 rand = { version = "0.8.0", default-features = false }
 bitcoin = { version = "0.32.4", default-features = false }
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -12,7 +12,8 @@ The lower-level `Handshake` and `PacketHandler` types can be directly used by ap
 
 * `alloc` -- Expose memory allocation dependent features.
 * `std`   -- Includes the `alloc` memory allocation feature as well as extra standard library dependencies for I/O and random number generators.
-* `async` -- High level wrappers for asynchronous read and write runtimes.
+* `async` -- High level wrappers for asynchronous read and write runtimes using agnostic futures-rs traits.
+* `tokio` -- Same wrappers as `async`, but using the popular tokio runtime's specific traits instead of futures-rs.
 
 ## Handshake
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -47,8 +47,13 @@ use bitcoin::{
     },
 };
 use fschacha20poly1305::{FSChaCha20, FSChaCha20Poly1305};
-#[cfg(feature = "async")]
+// Default to the futures-rs traits, but can overwrite with more specific
+// tokio implemenations for easier caller integration.
+#[cfg(all(feature = "async", not(feature = "tokio")))]
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+#[cfg(feature = "tokio")]
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
 use hkdf::Hkdf;
 use rand::Rng;
 
@@ -1064,7 +1069,7 @@ impl fmt::Display for ProtocolError {
 }
 
 /// A protocol session with handshake and send/receive packet management.
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 pub struct AsyncProtocol<R, W>
 where
     R: AsyncRead + Unpin + Send,
@@ -1074,7 +1079,7 @@ where
     writer: AsyncProtocolWriter<W>,
 }
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 impl<R, W> AsyncProtocol<R, W>
 where
     R: AsyncRead + Unpin + Send,
@@ -1213,7 +1218,7 @@ where
 }
 
 /// State machine of an asynchronous packet read.
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 #[derive(Debug)]
 enum DecryptState {
     ReadingLength {
@@ -1226,7 +1231,7 @@ enum DecryptState {
     },
 }
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 impl Default for DecryptState {
     fn default() -> Self {
         DecryptState::ReadingLength {
@@ -1237,7 +1242,7 @@ impl Default for DecryptState {
 }
 
 /// Manages an async buffer to automatically decrypt contents of received packets.
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 pub struct AsyncProtocolReader<R>
 where
     R: AsyncRead + Unpin + Send,
@@ -1247,7 +1252,7 @@ where
     state: DecryptState,
 }
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 impl<R> AsyncProtocolReader<R>
 where
     R: AsyncRead + Unpin + Send,
@@ -1298,7 +1303,7 @@ where
 }
 
 /// Manages an async buffer to automatically encrypt and send contents in packets.
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 pub struct AsyncProtocolWriter<W>
 where
     W: AsyncWrite + Unpin + Send,
@@ -1307,7 +1312,7 @@ where
     packet_writer: PacketWriter,
 }
 
-#[cfg(feature = "async")]
+#[cfg(any(feature = "async", feature = "tokio"))]
 impl<W> AsyncProtocolWriter<W>
 where
     W: AsyncWrite + Unpin + Send,

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -14,9 +14,8 @@ spec = "config_spec.toml"
 [dependencies]
 bitcoin = { version = "0.32.0" }
 tokio = { version = "1.37.0", features = ["full"] }
-tokio-util = { version = "0.7.12", features = ["compat"] }
 hex = { package = "hex-conservative", version = "0.2.0" }
-bip324 = { path = "../protocol", features = ["async"] }
+bip324 = { path = "../protocol", features = ["tokio"] }
 configure_me = "0.4.0"
 log = "0.4"
 env_logger = "0.10"

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -13,7 +13,6 @@ use tokio::{
     net::{TcpListener, TcpStream},
     select,
 };
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 configure_me::include_config!();
 
@@ -73,9 +72,6 @@ async fn v2_proxy(
 
     info!("Initiating handshake.");
     let (remote_reader, remote_writer) = remote.into_split();
-    // Convert to futures-compatible types.
-    let remote_reader = remote_reader.compat();
-    let remote_writer = remote_writer.compat_write();
 
     let protocol = match AsyncProtocol::new(
         network,


### PR DESCRIPTION
Ideally, the `tokio` flag was "additive" with the `async` one, but that would then unnecessarily include the futures dependency. 