### PR TITLE
Expose the underlying packet reader/writers

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1292,6 +1292,11 @@ impl AsyncProtocolReader {
             }
         }
     }
+
+    /// Consume the protocol reader in exchange for the underlying packet decoder.
+    pub fn decoder(self) -> PacketReader {
+        return self.packet_reader;
+    }
 }
 
 /// Manages an async buffer to automatically encrypt and send contents in packets.
@@ -1327,6 +1332,11 @@ impl AsyncProtocolWriter {
         buffer.write_all(&write_bytes[..]).await?;
         buffer.flush().await?;
         Ok(())
+    }
+
+    /// Consume the protocol writer in exchange for the underlying packet encoder.
+    pub fn encoder(self) -> PacketWriter {
+        return self.packet_writer;
     }
 }
 


### PR DESCRIPTION
The high level AsyncProtocol interface attemps to hide all the complexities of using the protocol, including things like cancellation safety. However, some callers might want the simplicity of the protocol handshake while handling the following encoding and decoding operations themselves to squeeze out performance.