### PR TITLE
Relax tokio version requirements

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,17 +11,17 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 # High-level wrappers using futures traits.
-async = ["std", "futures/std"]
+async = ["std", "dep:futures"]
 # High-level wrappers using tokio traits - may affect MSRV requirements.
-tokio = ["std", "tokio/io-util"]
+tokio = ["std", "dep:tokio"]
 std = ["alloc", "bitcoin/std", "bitcoin_hashes/std", "chacha20-poly1305/std", "rand/std", "rand/std_rng"]
 alloc = ["chacha20-poly1305/alloc"]
 
 [dependencies]
-futures = { version = "0.3.30", default-features = false, optional = true }
+futures = { version = "0.3.30", default-features = false, optional = true, features = ["std"] }
 # The tokio feature may increase the MSRV beyond 1.63.0
 # depending on which version of tokio is selected by the caller.
-tokio = { version = "1", default-features = false, optional = true }
+tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }
 rand = { version = "0.8.0", default-features = false }
 bitcoin = { version = "0.32.4", default-features = false }
 # Depending on hashes directly for HKDF, can drop this and 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -10,15 +10,18 @@ rust-version = "1.63.0"
 
 [features]
 default = ["std"]
+# High-level wrappers using futures traits.
 async = ["std", "futures/std"]
+# High-level wrappers using tokio traits - may affect MSRV requirements.
 tokio = ["std", "tokio/io-util"]
 std = ["alloc", "bitcoin/std", "bitcoin_hashes/std", "chacha20-poly1305/std", "rand/std", "rand/std_rng"]
 alloc = ["chacha20-poly1305/alloc"]
 
 [dependencies]
 futures = { version = "0.3.30", default-features = false, optional = true }
-# Must be under 1.39.0 due to MSRV 1.63.0 requirement.
-tokio = { version = ">=1.37.0, <1.39.0", default-features = false, optional = true }
+# The tokio feature may increase the MSRV beyond 1.63.0
+# depending on which version of tokio is selected by the caller.
+tokio = { version = "1", default-features = false, optional = true }
 rand = { version = "0.8.0", default-features = false }
 bitcoin = { version = "0.32.4", default-features = false }
 # Depending on hashes directly for HKDF, can drop this and 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -15,6 +15,12 @@ The lower-level `Handshake` and `PacketHandler` types can be directly used by ap
 * `async` -- High level wrappers for asynchronous read and write runtimes using agnostic futures-rs traits.
 * `tokio` -- Same wrappers as `async`, but using the popular tokio runtime's specific traits instead of futures-rs.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate has a baseline MSRV of **1.63.0**.
+
+However, the effective MSRV may be higher depending on the specific versions of dependencies selected by the caller. Currently, tokio is known to affect MSRV when using newer versions with the `tokio` feature flag, but other dependencies may also impact the effective MSRV in the future.
+
 ## Handshake
 
 Alice and Bob initiate a connection by sending three messages to each other to derive a number of shared secrets. Alice begins the connection by deriving a public/private keypair over `secp256k1`, the typical bitcoin curve. Alice is known as the *initiator*. She encodes the public key in the [Elligator Swift](https://eprint.iacr.org/2022/759.pdf) format (64-bytes), optionally pads it with some random garbage bytes, and sends the message to Bob. 


### PR DESCRIPTION
Allow any compatible Tokio 1.x version to be used with the tokio feature flag, rather than restricting to specific version ranges. This gives users more flexibility to select their preferred Tokio version. But when using the tokio feature with Tokio 1.39.0+, the effective MSRV increases to 1.70.0.

The library only depends on the stable tokio traits `AsyncRead`, `AsyncReadExt`, `AsyncWrite`, `AsyncWriteExt`, so should be compatible with a lot of versions. I'd rather give the caller control in this case, especially since its behind a feature flag, instead of enforcing the strict MSRV requirements of the library.