### PR TITLE
Rename "async" feature to "futures"

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.63.0"
 [features]
 default = ["std"]
 # High-level wrappers using futures traits.
-async = ["std", "dep:futures"]
+futures = ["std", "dep:futures"]
 # High-level wrappers using tokio traits - may affect MSRV requirements.
 tokio = ["std", "dep:tokio"]
 std = ["alloc", "bitcoin/std", "bitcoin_hashes/std", "chacha20-poly1305/std", "rand/std", "rand/std_rng"]

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -4,7 +4,7 @@ A BIP324 library to establish and communicate over an encrypted channel.
 
 The library is designed with a bare `no_std` and "Sans I/O" interface to keep it as agnostic as possible to application runtimes, but higher level interfaces are exposed for ease of use.
 
-The `async` feature includes the high-level `AsyncProcotol` type which helps create and manage an encrypted channel. 
+The `futures` feature includes the high-level `AsyncProcotol` type which helps create and manage an encrypted channel. 
 
 The lower-level `Handshake` and `PacketHandler` types can be directly used by applications which require more control. The handshake performs the one-and-a-half round trip dance between the peers in order to generate secret materials. A successful handshake results in a packet handler which performs the encrypt and decrypt operations for the lifetime of the channel.
 
@@ -12,8 +12,8 @@ The lower-level `Handshake` and `PacketHandler` types can be directly used by ap
 
 * `alloc` -- Expose memory allocation dependent features.
 * `std`   -- Includes the `alloc` memory allocation feature as well as extra standard library dependencies for I/O and random number generators.
-* `async` -- High level wrappers for asynchronous read and write runtimes using agnostic futures-rs traits.
-* `tokio` -- Same wrappers as `async`, but using the popular tokio runtime's specific traits instead of futures-rs.
+* `futures` -- High level wrappers for asynchronous read and write runtimes using agnostic futures-rs traits.
+* `tokio` -- Same wrappers as `futures`, but using the popular tokio runtime's specific traits instead of futures-rs.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -45,7 +45,7 @@ use bitcoin_hashes::{hkdf, sha256};
 use fschacha20poly1305::{FSChaCha20, FSChaCha20Poly1305};
 // Default to the futures-rs traits, but can overwrite with more specific
 // tokio implemenations for easier caller integration.
-#[cfg(all(feature = "async", not(feature = "tokio")))]
+#[cfg(all(feature = "futures", not(feature = "tokio")))]
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 #[cfg(feature = "tokio")]
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -1065,13 +1065,13 @@ impl fmt::Display for ProtocolError {
 }
 
 /// A protocol session with handshake and send/receive packet management.
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 pub struct AsyncProtocol {
     reader: AsyncProtocolReader,
     writer: AsyncProtocolWriter,
 }
 
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 impl AsyncProtocol {
     /// New protocol session which completes the initial handshake and returns a handler.
     ///
@@ -1206,7 +1206,7 @@ impl AsyncProtocol {
 }
 
 /// State machine of an asynchronous packet read.
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 #[derive(Debug)]
 enum DecryptState {
     ReadingLength {
@@ -1219,7 +1219,7 @@ enum DecryptState {
     },
 }
 
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 impl Default for DecryptState {
     fn default() -> Self {
         DecryptState::ReadingLength {
@@ -1230,13 +1230,13 @@ impl Default for DecryptState {
 }
 
 /// Manages an async buffer to automatically decrypt contents of received packets.
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 pub struct AsyncProtocolReader {
     packet_reader: PacketReader,
     state: DecryptState,
 }
 
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 impl AsyncProtocolReader {
     /// Decrypt contents of received packet from buffer.
     ///
@@ -1296,12 +1296,12 @@ impl AsyncProtocolReader {
 }
 
 /// Manages an async buffer to automatically encrypt and send contents in packets.
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 pub struct AsyncProtocolWriter {
     packet_writer: PacketWriter,
 }
 
-#[cfg(any(feature = "async", feature = "tokio"))]
+#[cfg(any(feature = "futures", feature = "tokio"))]
 impl AsyncProtocolWriter {
     /// Encrypt contents and write packet buffer.
     ///


### PR DESCRIPTION
Follow the convention that a feature's name maps to the dependency.