### PR TITLE
fix: lower bitcoin crate version requirement

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -24,7 +24,7 @@ futures = { version = "0.3.30", default-features = false, optional = true, featu
 # depending on which version of tokio is selected by the caller.
 tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }
 rand = { version = "0.8.0", default-features = false }
-bitcoin = { version = "0.32.4", default-features = false }
+bitcoin = { version = "0.32.0", default-features = false }
 # Depending on hashes directly for HKDF, can drop this and 
 # use the re-exported version in bitcoin > 0.32.*.
 bitcoin_hashes = { version ="0.15.0", default-features = false }

--- a/protocol/src/serde.rs
+++ b/protocol/src/serde.rs
@@ -294,7 +294,7 @@ struct HeaderDeserializationWrapper(Vec<block::Header>);
 
 impl Decodable for HeaderDeserializationWrapper {
     #[inline]
-    fn consensus_decode_from_finite_reader<R: bitcoin::io::Read + ?Sized>(
+    fn consensus_decode_from_finite_reader<R: bitcoin::io::Read + bitcoin::io::BufRead + ?Sized>(
         r: &mut R,
     ) -> Result<Self, encode::Error> {
         let len = VarInt::consensus_decode(r)?.0;

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 spec = "config_spec.toml"
 
 [dependencies]
-bitcoin = { version = "0.32.4" }
+bitcoin = { version = "0.32.0" }
 tokio = { version = "1", features = ["full"] }
 hex = { package = "hex-conservative", version = "0.2.0" }
 bip324 = { path = "../protocol", features = ["tokio"] }


### PR DESCRIPTION
* From 0.32.4 to 0.32.0, more flexibility for consumers.