### PR TITLE
fix: impl source function in errors for context

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -130,7 +130,20 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::CiphertextTooSmall => None,
+            Error::BufferTooSmall { .. } => None,
+            Error::NoGarbageTerminator => None,
+            Error::HandshakeOutOfOrder => None,
+            Error::V1Protocol => None,
+            Error::SecretGeneration(e) => Some(e),
+            Error::Decryption(e) => Some(e),
+            Error::TooMuchGarbage => None,
+        }
+    }
+}
 
 impl From<fschacha20poly1305::Error> for Error {
     fn from(e: fschacha20poly1305::Error) -> Self {
@@ -1056,7 +1069,14 @@ impl From<Error> for ProtocolError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ProtocolError {}
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ProtocolError::Io(e, _) => Some(e),
+            ProtocolError::Internal(e) => Some(e),
+        }
+    }
+}
 
 #[cfg(feature = "std")]
 impl fmt::Display for ProtocolError {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -49,7 +49,17 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::WrongNetwork => None,
+            Error::WrongCommand => None,
+            Error::Serde => None,
+            Error::Io(e) => Some(e),
+            Error::Protocol(e) => Some(e),
+        }
+    }
+}
 
 impl From<bip324::ProtocolError> for Error {
     fn from(e: bip324::ProtocolError) -> Self {


### PR DESCRIPTION
The default source function of the standard library `error` trait just returns a `None`, which strips the error of its originating context.