### PR TITLE
Explicit toolchain versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,11 @@ on:
 jobs:
   # Quick canary of code as well as potential issues with upcoming toolchains.
   check:
-    strategy:
-      matrix:
-        toolchain: [stable, beta, nightly]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: clippy,rustfmt
       - run: just check
   # Build and test the code across platforms.
   test:
@@ -48,15 +42,13 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: just test msrv
-  min-versions:
+  constraints:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly
-      - run: just test min-versions
+      - run: just test constraints
   no-std:
     runs-on: ubuntu-latest
     steps:
@@ -71,6 +63,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly
       - run: just fuzz

--- a/justfile
+++ b/justfile
@@ -1,52 +1,74 @@
-_default:
+# Every commit on the master branch is expected to have working `check` and `test-*` recipes.
+#
+# The recipes make heavy use of `rustup`'s toolchain syntax (e.g. `cargo +nightly`). `rustup` is
+# required on the system in order to intercept the `cargo` commands and to install and use the appropriate toolchain with components. 
+
+NIGHTLY_TOOLCHAIN := "nightly-2025-06-19"
+STABLE_TOOLCHAIN := "1.87.0"
+
+@_default:
   @just --list
 
 # Quick check of the code including lints and formatting.
-check:
-  cargo fmt --check
-  # Turn warnings into errors.
-  cargo clippy --all-targets -- -D warnings
-  cargo check --all-features
+@check:
+  # Default to the nightly toolchain for modern format and lint rules.
 
-# Run a test suite: unit, features, msrv, min-versions, or no-std.
-test suite="unit":
+  # Ensure the toolchain is installed and has the necessary components.
+  rustup component add --toolchain {{NIGHTLY_TOOLCHAIN}} rustfmt clippy
+  # Cargo's wrapper for rustfmt predates workspaces, so uses the "--all" flag instead of "--workspaces".
+  cargo +{{NIGHTLY_TOOLCHAIN}} fmt --check --all
+  # Lint all workspace members. Enable all feature flags. Check all targets (tests, examples) along with library code. Turn warnings into errors.
+  cargo +{{NIGHTLY_TOOLCHAIN}} clippy --workspace --all-features --all-targets -- -D warnings
+
+# Run a test suite: unit, features, msrv, constraints, or no-std.
+@test suite="unit":
   just _test-{{suite}}
 
 # Unit test suite.
-_test-unit:
-  cargo test --all-targets
-  cargo test --doc
+@_test-unit:
+  cargo +{{STABLE_TOOLCHAIN}} test --all-targets
+  cargo +{{STABLE_TOOLCHAIN}} test --doc
 
 # Test feature flag matrix compatability.
-_test-features:
+@_test-features:
   # Build and test with all features, no features, and some combinations.
-  cargo test --package bip324 --lib --all-features
-  cargo test --package bip324 --lib --no-default-features
-  cargo test --package bip324 --lib --no-default-features --features alloc 
+  cargo +{{STABLE_TOOLCHAIN}} test --package bip324 --lib --all-features
+  cargo +{{STABLE_TOOLCHAIN}} test --package bip324 --lib --no-default-features
+  cargo +{{STABLE_TOOLCHAIN}} test --package bip324 --lib --no-default-features --features alloc 
 
 # Check code with MSRV compiler.
-_test-msrv:
+@_test-msrv:
   # Handles creating sandboxed environments to ensure no newer binaries sneak in.
   cargo install cargo-msrv@0.18.4
   cargo msrv --manifest-path protocol/Cargo.toml verify --all-features
 
-# Test that minimum versions of dependency contraints are valid.
-_test-min-versions:
+# Check minimum and maximum dependency contraints.
+@_test-constraints:
+  # Ensure that the workspace code works with dependency versions at both extremes. This checks
+  # that we are not unintentionally using new feautures of a dependency or removed ones.
+
+  # Skipping "--all-targets" for these checks since tests and examples are not relevant for a library consumer.
+  # Enabling "--all-features" so all dependencies are checked.
+  # Clear any previously resolved versions and re-resolve to the minimums.
   rm -f Cargo.lock
-  cargo +nightly check --all-features -Z direct-minimal-versions
+  cargo +{{NIGHTLY_TOOLCHAIN}} check --workspace --all-features -Z direct-minimal-versions
+  # Clear again and check the maximums by ignoring any rust-version caps. 
+  rm -f Cargo.lock
+  cargo +{{NIGHTLY_TOOLCHAIN}} check --workspace --all-features --ignore-rust-version
+  rm -f Cargo.lock
 
 # Test no standard library support.
-_test-no-std:
+@_test-no-std:
   cargo install cross@0.2.5
   $HOME/.cargo/bin/cross build --package bip324 --target thumbv7m-none-eabi --no-default-features --features alloc
 
 # Run fuzz test: handshake.
-fuzz target="handshake" time="60":
+@fuzz target="handshake" time="60":
   cargo install cargo-fuzz@0.12.0
-  cd protocol && cargo +nightly fuzz run {{target}} -- -max_total_time={{time}}
+  cd protocol && cargo +{{NIGHTLY_TOOLCHAIN}} fuzz run {{target}} -- -max_total_time={{time}}
 
 # Add a release tag and publish to the upstream remote. Need write privileges on the repository.
-tag crate version remote="upstream":
+@tag crate version remote="upstream":
   # A release tag is specific to a crate so following the convention crate-version.
   echo "Adding release tag {{crate}}-{{version}} and pushing to {{remote}}..."
   # Annotated tag.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.85.0"
-components = ["rustfmt", "clippy"]
-targets = ["thumbv7m-none-eabi"]


### PR DESCRIPTION
Making toolchain versions explicit instead of floating. I think this will also help with my benches addition to iron out some unstable feature usage.

Dropping the `rust-toolchain.toml` because while it has nice integration with `rustup` to auto-download a toolchain, it has a very weird bug with clippy. Specifically around workspaces which make use of MSRVs, it sometimes resolves a crate to the wrong MSRV and fails some clippy rules. Not worth dealing with it.