### PR TITLE
Remove the futures flag

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,14 +11,11 @@ rust-version = "1.63.0"
 
 [features]
 default = ["std"]
-# High-level wrappers using futures traits.
-futures = ["std", "dep:futures"]
 # High-level wrappers using tokio traits - may affect MSRV requirements.
 tokio = ["std", "dep:tokio"]
 std = ["bitcoin/std", "bitcoin_hashes/std", "chacha20-poly1305/std", "rand/std", "rand/std_rng"]
 
 [dependencies]
-futures = { version = "0.3.30", default-features = false, optional = true, features = ["std"] }
 # The tokio feature may increase the MSRV beyond 1.63.0
 # depending on which version of tokio is selected by the caller.
 tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -4,15 +4,14 @@ A BIP324 library to establish and communicate over an encrypted channel.
 
 The library is designed with a bare `no_std` and "Sans I/O" interface to keep it as agnostic as possible to application runtimes, but higher level interfaces are exposed for ease of use.
 
-The `futures` feature includes the high-level `AsyncProcotol` type which helps create and manage an encrypted channel. 
+The `tokio` feature includes the high-level `AsyncProcotol` type which helps create and manage an encrypted channel. 
 
 The lower-level `CipherSession` and `Handshake` types can be directly used by applications which require more control. The handshake performs the one-and-a-half round trip dance between the peers in order to generate secret materials and verify a channel. A successful handshake results in a cipher session which performs the encrypt and decrypt operations for the lifetime of the channel.
 
 ## Feature Flags
 
 * `std` -- Standard library dependencies for I/O, memory allocation, and random number generators.
-* `futures` -- High level wrappers for asynchronous read and write runtimes using agnostic futures-rs traits.
-* `tokio` -- Same wrappers as `futures`, but using the popular tokio runtime's specific traits instead of futures-rs.
+* `tokio` -- High level I/O wrappers for asynchronous tokio runtime.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/protocol/src/io.rs
+++ b/protocol/src/io.rs
@@ -4,14 +4,19 @@
 //! connections over Read/Write transports.
 
 use core::fmt;
+#[cfg(feature = "tokio")]
 use std::vec;
 use std::vec::Vec;
 
+use crate::{Error, PacketType};
+
+#[cfg(feature = "tokio")]
 use bitcoin::Network;
 
+#[cfg(feature = "tokio")]
 use crate::{
     handshake::{self, GarbageResult, VersionResult},
-    Error, Handshake, InboundCipher, OutboundCipher, PacketType, Role, NUM_ELLIGATOR_SWIFT_BYTES,
+    Handshake, InboundCipher, OutboundCipher, Role, NUM_ELLIGATOR_SWIFT_BYTES,
     NUM_GARBAGE_TERMINTOR_BYTES,
 };
 
@@ -93,6 +98,7 @@ impl ProtocolError {
     ///
     /// This is used when the remote peer closes the connection during handshake,
     /// which often indicates they don't support the V2 protocol.
+    #[cfg(feature = "tokio")]
     fn eof() -> Self {
         ProtocolError::Io(
             std::io::Error::new(

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -23,7 +23,7 @@ extern crate std;
 
 mod fschacha20poly1305;
 mod handshake;
-#[cfg(any(feature = "futures", feature = "tokio"))]
+#[cfg(feature = "std")]
 pub mod io;
 #[cfg(feature = "std")]
 pub mod serde;
@@ -43,14 +43,7 @@ pub use handshake::{
     GarbageResult, Handshake, Initialized, ReceivedGarbage, ReceivedKey, SentKey, SentVersion,
     VersionResult,
 };
-// Re-exports from io module (async I/O types for backwards compatibility)
-#[cfg(any(feature = "futures", feature = "tokio"))]
-pub use io::{
-    AsyncProtocol, AsyncProtocolReader, AsyncProtocolWriter, Payload, ProtocolError,
-    ProtocolFailureSuggestion,
-};
 
-// Internal imports
 use fschacha20poly1305::{FSChaCha20, FSChaCha20Poly1305};
 
 /// Value for header byte with the decoy flag flipped to true.

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -6,8 +6,9 @@
 use std::str::FromStr;
 
 use bip324::{
+    io::{AsyncProtocol, ProtocolFailureSuggestion},
     serde::{deserialize, serialize},
-    AsyncProtocol, PacketType, ProtocolFailureSuggestion, Role,
+    PacketType, Role,
 };
 use bip324_proxy::{V1ProtocolReader, V1ProtocolWriter};
 use bitcoin::Network;
@@ -87,7 +88,7 @@ async fn v2_proxy(
     .await
     {
         Ok(p) => p,
-        Err(bip324::ProtocolError::Io(_, ProtocolFailureSuggestion::RetryV1)) if v1_fallback => {
+        Err(bip324::io::ProtocolError::Io(_, ProtocolFailureSuggestion::RetryV1)) if v1_fallback => {
             info!("V2 protocol failed, falling back to V1...");
             return v1_proxy(client, network).await;
         }

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -88,7 +88,9 @@ async fn v2_proxy(
     .await
     {
         Ok(p) => p,
-        Err(bip324::io::ProtocolError::Io(_, ProtocolFailureSuggestion::RetryV1)) if v1_fallback => {
+        Err(bip324::io::ProtocolError::Io(_, ProtocolFailureSuggestion::RetryV1))
+            if v1_fallback =>
+        {
             info!("V2 protocol failed, falling back to V1...");
             return v1_proxy(client, network).await;
         }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -34,7 +34,7 @@ pub enum Error {
     WrongCommand,
     Serde,
     Io(std::io::Error),
-    Protocol(bip324::ProtocolError),
+    Protocol(bip324::io::ProtocolError),
 }
 
 impl fmt::Display for Error {
@@ -61,8 +61,8 @@ impl std::error::Error for Error {
     }
 }
 
-impl From<bip324::ProtocolError> for Error {
-    fn from(e: bip324::ProtocolError) -> Self {
+impl From<bip324::io::ProtocolError> for Error {
+    fn from(e: bip324::io::ProtocolError) -> Self {
         Error::Protocol(e)
     }
 }


### PR DESCRIPTION
Simplifying the protocol crate's interface by dropping the more general futures flag in favor of just the tokio one. All users of the library have been tokio runtime users. If the rust standard library gets its act together and adopts some async I/O interfaces, those will be used in the future instead. Until then, simplifying the interface to explore other things like ffi bindings.