### PR TITLE
Make serialize function infallible and remove error variant.

### DIFF
--- a/protocol/tests/round_trips.rs
+++ b/protocol/tests/round_trips.rs
@@ -271,7 +271,7 @@ fn regtest_handshake() {
         start_height: 0,
         relay: false,
     };
-    let message = serialize(NetworkMessage::Version(msg)).unwrap();
+    let message = serialize(NetworkMessage::Version(msg));
     let packet_len = bip324::OutboundCipher::encryption_buffer_len(message.len());
     let mut packet = vec![0u8; packet_len];
     encrypter

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -114,7 +114,7 @@ async fn v2_proxy(
                     msg.command()
                 );
 
-                let contents = serialize(msg).expect("serialize-able contents into network message");
+                let contents = serialize(msg);
                 v2_remote_writer
                     .encrypt_and_write(&contents, &mut remote_writer)
                     .await


### PR DESCRIPTION
The underlying functions only fail on I/O which doesn't occur when writing to an in memory vector.

closes #114 