### PR TITLE
protocol: Update `hashes` to `0.16.0`

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", default-features = false, optional = true, features = [
 bitcoin = { version = "0.32.4", default-features = false }
 # Depending on hashes directly for HKDF, can drop this and 
 # use the re-exported version in bitcoin > 0.32.*.
-bitcoin_hashes = { version ="0.15.0", default-features = false }
+bitcoin_hashes = { version =">=0.15.0, <0.17.0", default-features = false }
 chacha20-poly1305 = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
The `hashes` dependency made `hex-conservative` optional. With the likely removal of `hashes` from `secp256k1`, we can choose what `hashes` version we would like without duplicates.