### PR TITLE
Add session_id accessors to Protocol and async Protocol

### DIFF
--- a/protocol/src/futures.rs
+++ b/protocol/src/futures.rs
@@ -60,8 +60,9 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use crate::{
     handshake::{self, GarbageResult, VersionResult},
     io::{Payload, ProtocolError},
-    Error, Handshake, InboundCipher, OutboundCipher, Role, MAX_PACKET_SIZE_FOR_ALLOCATION,
-    NUM_ELLIGATOR_SWIFT_BYTES, NUM_GARBAGE_TERMINTOR_BYTES, NUM_LENGTH_BYTES,
+    Error, Handshake, InboundCipher, OutboundCipher, Role, SessionId,
+    MAX_PACKET_SIZE_FOR_ALLOCATION, NUM_ELLIGATOR_SWIFT_BYTES, NUM_GARBAGE_TERMINTOR_BYTES,
+    NUM_LENGTH_BYTES,
 };
 
 /// An async reader that chains unconsumed handshake data with the underlying stream.
@@ -155,7 +156,15 @@ pub async fn handshake<R, W>(
     decoys: Option<Vec<Vec<u8>>>,
     mut reader: R,
     writer: &mut W,
-) -> Result<(InboundCipher, OutboundCipher, ProtocolSessionReader<R>), ProtocolError>
+) -> Result<
+    (
+        InboundCipher,
+        OutboundCipher,
+        ProtocolSessionReader<R>,
+        SessionId,
+    ),
+    ProtocolError,
+>
 where
     R: AsyncRead + Send + Unpin,
     W: AsyncWrite + Unpin,
@@ -237,8 +246,9 @@ where
         session_reader.read_exact(&mut packet_bytes).await?;
         match handshake.receive_version(&mut packet_bytes) {
             Ok(VersionResult::Complete { cipher }) => {
+                let session_id = *cipher.id();
                 let (inbound_cipher, outbound_cipher) = cipher.into_split();
-                return Ok((inbound_cipher, outbound_cipher, session_reader));
+                return Ok((inbound_cipher, outbound_cipher, session_reader, session_id));
             }
             Ok(VersionResult::Decoy(h)) => {
                 handshake = h;
@@ -252,6 +262,7 @@ where
 pub struct Protocol<R, W> {
     reader: ProtocolReader<R>,
     writer: ProtocolWriter<W>,
+    session_id: SessionId,
 }
 
 impl<R, W> Protocol<R, W>
@@ -294,7 +305,7 @@ where
         reader: R,
         mut writer: W,
     ) -> Result<Protocol<R, W>, ProtocolError> {
-        let (inbound_cipher, outbound_cipher, session_reader) =
+        let (inbound_cipher, outbound_cipher, session_reader, session_id) =
             handshake(magic, role, garbage, decoys, reader, &mut writer).await?;
 
         Ok(Protocol {
@@ -307,6 +318,7 @@ where
                 outbound_cipher,
                 writer,
             },
+            session_id,
         })
     }
 
@@ -341,6 +353,13 @@ where
     ///   * `Err(ProtocolError)`: An error that occurred during the encryption or write.
     pub async fn write(&mut self, payload: &Payload) -> Result<(), ProtocolError> {
         self.writer.write(payload).await
+    }
+
+    /// Returns the 32-byte session identifier derived during the BIP-324 handshake.
+    ///
+    /// This value is unique to the established connection.
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
     }
 }
 

--- a/protocol/src/io.rs
+++ b/protocol/src/io.rs
@@ -52,7 +52,7 @@ use std::vec::Vec;
 
 use crate::{
     handshake::{self, GarbageResult, VersionResult},
-    Error, Handshake, InboundCipher, OutboundCipher, PacketType, Role,
+    Error, Handshake, InboundCipher, OutboundCipher, PacketType, Role, SessionId,
     MAX_PACKET_SIZE_FOR_ALLOCATION, NUM_ELLIGATOR_SWIFT_BYTES, NUM_GARBAGE_TERMINTOR_BYTES,
     NUM_LENGTH_BYTES,
 };
@@ -284,7 +284,15 @@ pub fn handshake<R, W>(
     decoys: Option<Vec<Vec<u8>>>,
     reader: R,
     writer: &mut W,
-) -> Result<(InboundCipher, OutboundCipher, ProtocolSessionReader<R>), ProtocolError>
+) -> Result<
+    (
+        InboundCipher,
+        OutboundCipher,
+        ProtocolSessionReader<R>,
+        SessionId,
+    ),
+    ProtocolError,
+>
 where
     R: Read,
     W: Write,
@@ -311,7 +319,7 @@ where
 /// # Returns
 ///
 /// A `Result` containing:
-///   * `Ok((InboundCipher, OutboundCipher, ProtocolSessionReader<R>))`: Ready-to-use session components.
+///   * `Ok((InboundCipher, OutboundCipher, ProtocolSessionReader<R>, SessionId))`: Ready-to-use session components.
 ///   * `Err(ProtocolError)`: An error that occurred during the handshake.
 ///
 /// # Errors
@@ -323,7 +331,15 @@ fn handshake_with_initialized<R, W>(
     decoys: Option<Vec<Vec<u8>>>,
     mut reader: R,
     writer: &mut W,
-) -> Result<(InboundCipher, OutboundCipher, ProtocolSessionReader<R>), ProtocolError>
+) -> Result<
+    (
+        InboundCipher,
+        OutboundCipher,
+        ProtocolSessionReader<R>,
+        SessionId,
+    ),
+    ProtocolError,
+>
 where
     R: Read,
     W: Write,
@@ -403,8 +419,9 @@ where
         session_reader.read_exact(&mut packet_bytes)?;
         match handshake.receive_version(&mut packet_bytes) {
             Ok(VersionResult::Complete { cipher }) => {
+                let session_id = *cipher.id();
                 let (inbound_cipher, outbound_cipher) = cipher.into_split();
-                return Ok((inbound_cipher, outbound_cipher, session_reader));
+                return Ok((inbound_cipher, outbound_cipher, session_reader, session_id));
             }
             Ok(VersionResult::Decoy(h)) => {
                 handshake = h;
@@ -418,6 +435,7 @@ where
 pub struct Protocol<R, W> {
     reader: ProtocolReader<R>,
     writer: ProtocolWriter<W>,
+    session_id: SessionId,
 }
 
 impl<R, W> Protocol<R, W>
@@ -458,7 +476,7 @@ where
         reader: R,
         mut writer: W,
     ) -> Result<Protocol<R, W>, ProtocolError> {
-        let (inbound_cipher, outbound_cipher, session_reader) =
+        let (inbound_cipher, outbound_cipher, session_reader, session_id) =
             handshake(magic, role, garbage, decoys, reader, &mut writer)?;
 
         Ok(Protocol {
@@ -470,6 +488,7 @@ where
                 outbound_cipher,
                 writer,
             },
+            session_id,
         })
     }
 
@@ -502,6 +521,13 @@ where
     ///   * `Err(ProtocolError)`: An error that occurred during the encryption or write.
     pub fn write(&mut self, payload: &Payload) -> Result<(), ProtocolError> {
         self.writer.write(payload)
+    }
+
+    /// Returns the 32-byte session identifier derived during the BIP-324 handshake.
+    ///
+    /// This value is unique to the established connection.
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
     }
 }
 
@@ -689,7 +715,7 @@ mod tests {
         let result = handshake_with_initialized(init_handshake, None, None, reader, &mut writer);
 
         // Verify the session reader contains exactly the extra byte we added.
-        let (_, _, mut session_reader) = result.unwrap();
+        let (_, _, mut session_reader, _) = result.unwrap();
         let mut buffer = [0u8; 1];
         match session_reader.read(&mut buffer) {
             Ok(1) => {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -290,11 +290,33 @@ impl From<hkdf::MaxLengthError> for Error {
     }
 }
 
+/// A 32-byte session identifier, unique to a BIP-324 connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SessionId([u8; 32]);
+
+impl SessionId {
+    /// Returns the inner 32-byte array.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Returns a copy of the underlying bytes.
+    pub fn to_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for SessionId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// All keys derived from the ECDH.
 #[derive(Clone)]
 pub struct SessionKeyMaterial {
     /// A unique ID to identify a connection.
-    pub session_id: [u8; 32],
+    pub session_id: SessionId,
     initiator_length_key: [u8; 32],
     initiator_packet_key: [u8; 32],
     responder_length_key: [u8; 32],
@@ -362,7 +384,7 @@ impl SessionKeyMaterial {
             .try_into()
             .expect("last 16 bytes of expanded garbage");
         Ok(SessionKeyMaterial {
-            session_id,
+            session_id: SessionId(session_id),
             initiator_length_key,
             initiator_packet_key,
             responder_length_key,
@@ -692,7 +714,7 @@ impl OutboundCipher {
 #[derive(Clone)]
 pub struct CipherSession {
     /// A unique identifier for the communication session.
-    id: [u8; 32],
+    id: SessionId,
     /// Decrypts inbound packets.
     inbound: InboundCipher,
     /// Encrypts outbound packets.
@@ -744,7 +766,7 @@ impl CipherSession {
     }
 
     /// Unique session ID.
-    pub fn id(&self) -> &[u8; 32] {
+    pub fn id(&self) -> &SessionId {
         &self.id
     }
 
@@ -1166,9 +1188,10 @@ mod tests {
         .unwrap();
         let id = session_keys.session_id;
         assert_eq!(
-            id.to_vec(),
+            id.as_ref(),
             Vec::from_hex("b0490e26111cb2d55bbff2ace00f7f644f64006539abb4e7513f05107bb10608")
                 .unwrap()
+                .as_slice()
         );
         let mut alice_cipher = CipherSession::new(session_keys.clone(), Role::Responder);
         let contents: Vec<u8> = Vec::from_hex("3eb1d4e98035cfd8eeb29bac969ed3824a").unwrap();
@@ -1240,9 +1263,10 @@ mod tests {
         .unwrap();
         let id = session_keys.session_id;
         assert_eq!(
-            id.to_vec(),
+            id.as_ref(),
             Vec::from_hex("279a96e6ce08e5074608fcad77d6a78f90c8b618a4520575435b1a37b1c56df9")
                 .unwrap()
+                .as_slice()
         );
         let mut alice_cipher = CipherSession::new(session_keys.clone(), Role::Responder);
         let contents: Vec<u8> = Vec::from_hex("7e0e78eb6990b059e6cf0ded66ea93ef82e72aa2f18ac24f2fc6ebab561ae557420729da103f64cecfa20527e15f9fb669a49bbbf274ef0389b3e43c8c44e5f60bf2ac38e2b55e7ec4273dba15ba41d21f8f5b3ee1688b3c29951218caf847a97fb50d75a86515d445699497d968164bf740012679b8962de573be941c62b7ef").unwrap();

--- a/protocol/tests/round_trips.rs
+++ b/protocol/tests/round_trips.rs
@@ -181,6 +181,8 @@ fn pingpong_with_closed_connection_sync() {
         )
         .expect("Failed to create protocol");
 
+        let session_id = *protocol.session_id();
+
         // Read one message
         let payload = protocol.read().expect("Failed to read payload");
         let received_message = consensus::deserialize::<V2NetworkMessage>(payload.contents())
@@ -196,6 +198,7 @@ fn pingpong_with_closed_connection_sync() {
         } else {
             panic!("Expected Ping, but received: {received_message:?}");
         }
+        session_id
     });
 
     let stream = TcpStream::connect(addr).unwrap();
@@ -213,6 +216,8 @@ fn pingpong_with_closed_connection_sync() {
     )
     .expect("Failed to create protocol");
 
+    let session_id = *protocol.session_id();
+
     println!("Sending Ping using sync Protocol::write()");
     let ping = V2NetworkMessage::new(NetworkMessage::Ping(45324));
     let message = consensus::serialize(&ping);
@@ -228,7 +233,9 @@ fn pingpong_with_closed_connection_sync() {
     assert_eq!(NetworkMessage::Pong(45324), *response_message.payload());
 
     println!("Successfully ping-pong'ed using sync Protocol API!");
-    server.join().unwrap();
+    let server_session_id = server.join().unwrap();
+
+    assert_eq!(session_id, server_session_id);
 
     println!(
         "Trying to read another message from the server, while the connection is already closed."
@@ -263,6 +270,8 @@ async fn pingpong_with_closed_connection_async() {
         .await
         .unwrap();
 
+        let session_id = *protocol.session_id();
+
         let payload = protocol.read().await.unwrap();
         let received_message =
             consensus::deserialize::<V2NetworkMessage>(payload.contents()).unwrap();
@@ -274,6 +283,8 @@ async fn pingpong_with_closed_connection_async() {
         } else {
             panic!("Expected Ping, but received: {received_message:?}");
         }
+
+        session_id
     });
 
     let stream = TcpStream::connect(addr).await.unwrap();
@@ -293,6 +304,8 @@ async fn pingpong_with_closed_connection_async() {
     .await
     .unwrap();
 
+    let session_id = *protocol.session_id();
+
     println!("Sending Ping using async Protocol::write()");
     let ping = V2NetworkMessage::new(NetworkMessage::Ping(45324));
     let message = consensus::serialize(&ping);
@@ -305,7 +318,9 @@ async fn pingpong_with_closed_connection_async() {
     assert_eq!(NetworkMessage::Pong(45324), *response_message.payload());
 
     println!("Successfully ping-pong message using async Protocol API!");
-    server.await.unwrap();
+    let server_session_id = server.await.unwrap();
+
+    assert_eq!(session_id, server_session_id);
 
     println!(
         "Trying to read another message from the server, while the connection is already closed."


### PR DESCRIPTION
Add Protocol::session_id() to sync and async `Protocol`
Update round trip tests to verify both peers derive the same session ID
Fixes #61 