### PR TITLE
Update `bitcoind` across crates

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -27,7 +27,7 @@ chacha20-poly1305 = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
 # bitcoind version 26.0 includes support for BIP-324's V2 protocol, but it is disabled by default.
-bitcoind = { package = "corepc-node", version = "0.7.1", default-features = false, features = ["26_0","download"] }
+bitcoind = { package = "corepc-node", version = "0.12.0", default-features = false, features = ["30_2", "download"] }
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
 p2p = { package = "bitcoin-p2p-messages",  git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
 hex = { package = "hex-conservative", version = "0.2.0" }

--- a/traffic/Cargo.toml
+++ b/traffic/Cargo.toml
@@ -18,7 +18,7 @@ rand = { version = "0.8" }
 tokio = { version = "1", features = ["sync", "time", "rt", "macros"], optional = true }
 
 [dev-dependencies]
-bitcoind = { package = "corepc-node", version = "0.7.1", default-features = false, features = ["26_0","download"] }
+bitcoind = { package = "corepc-node", version = "0.12.0", default-features = false, features = ["30_2","download"] }
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
 p2p = { package = "bitcoin-p2p-messages",  git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "16cc257c3695dea0e7301a5fa9cab44b8ed60598" }
 tokio = { version = "1", features = ["sync", "time", "rt", "macros", "net", "io-util"] }


### PR DESCRIPTION
Updates corepc and bumps the bitcoind version from 26.0 to 30.2